### PR TITLE
Add user field to post type

### DIFF
--- a/app/graphql/types/post_type.rb
+++ b/app/graphql/types/post_type.rb
@@ -7,5 +7,10 @@ module Types
     field :description, String, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    field :user, Types::UserType, null: false
+    def user
+      object.user
+    end
   end
 end


### PR DESCRIPTION
This PR adds the user field to the post type, which returns the sender of the post.